### PR TITLE
Set provider name to tardigrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ velero-backup-location-create: .is-access-set ## create a backup location using 
 	@velero backup-location create $(VELERO_BACKUP_LOCATION) \
 		--bucket=$(BUCKET_NAME) \
 		--config accessGrant=$(STORJ_ACCESS) \
-		--provider=gcp
+		--provider=tardigrade
 
 .PHONY: velero-backup-location-delete
 velero-backup-location-delete: ## delete the backup location that uses Storj plugin

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,7 @@ endif
 
 .PHONY: plugin-build
 plugin-build: ## build docker image of this Velero plugin for development
-<<<<<<< HEAD
 	@docker image build --rm -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
-=======
-	@docker image build --squash --rm -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
->>>>>>> 8e8fa25... Makefile: Create a local K8s cluster & more
 
 .PHONY: plugin-image-push
 plugin-image-push: ## push the plugin image to the local  K8s cluster

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,11 @@ endif
 
 .PHONY: plugin-build
 plugin-build: ## build docker image of this Velero plugin for development
+<<<<<<< HEAD
 	@docker image build --rm -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+=======
+	@docker image build --squash --rm -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
+>>>>>>> 8e8fa25... Makefile: Create a local K8s cluster & more
 
 .PHONY: plugin-image-push
 plugin-image-push: ## push the plugin image to the local  K8s cluster

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here we implement a Velero Object Store Plugin that is backed by Storj object st
 ### Install velero with Storj plugin
 
 ```
-$ velero install --provider gcp \
+$ velero install --provider tardigrade \
     --plugins storjthirdparty/velero-plugin:v0.1.0 \
     --bucket $BUCKET \
     --backup-location-config accessGrant=$ACCESS \

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	veleroplugin.NewServer().
 		BindFlags(pflag.CommandLine).
-		RegisterObjectStore("velero.io/gcp", newStorjObjectStore).
+		RegisterObjectStore("velero.io/tardigrade", newStorjObjectStore).
 		Serve()
 }
 


### PR DESCRIPTION
We were using "gcp" as provider name. This PR changes it to "tardigrade"